### PR TITLE
Feat: Implementar Contexto de metricas de notas

### DIFF
--- a/src/components/ButtonProfile/ButtonProfile.style.js
+++ b/src/components/ButtonProfile/ButtonProfile.style.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { device } from "../../constants/index";
 
 export const ContainerProfile = styled.button`
     display: flex;
@@ -18,6 +19,10 @@ export const ContainerProfile = styled.button`
 
     &:hover {
         border-color: #666;
+    }
+
+    @media ${device.xs} {
+        display: none;
     }
 `;
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -3,8 +3,8 @@ import { Header, LoginButton, WrapperTitle } from "./Header.style";
 import { SearchBar } from "../SearchBar/SearchBar";
 import { Link } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
-
-export default function HeaderNav({ showSearchBar = true, onSearch }) {
+ 
+function HeaderNav({ showSearchBar = true, onSearch }) {
 	const { acessToken } = useAuth();
 
 	return (
@@ -38,3 +38,6 @@ export default function HeaderNav({ showSearchBar = true, onSearch }) {
 		</Header>
 	);
 }
+
+
+export { HeaderNav };

--- a/src/components/Metrics/GrapicTasks/GrapicTasks.jsx
+++ b/src/components/Metrics/GrapicTasks/GrapicTasks.jsx
@@ -1,25 +1,7 @@
 import { ContentGraphicsOne } from "./GrapicTasks.styles.js";
 import Chart from "../Chart/index.jsx";
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
-import { getMetrics } from "../../../services/metricsService.js";
 
 export function GrapicTasks() {
-	const [analyticsDataState, setAnalyticsDataState] = useState();
-
-	useEffect(() => {
-		const fechTotalTasksBytype = async () => {
-			try {
-				const response = await getMetrics();
-				setAnalyticsDataState(response);
-			} catch (error) {
-				toast.error("Erro ao carregar os dados");
-			}
-		};
-
-		fechTotalTasksBytype();
-	}, []);
-
 	const options = {
 		title: {
 			text: "",

--- a/src/components/Metrics/TotalCompletedTasks/TotalCompletedTasks.jsx
+++ b/src/components/Metrics/TotalCompletedTasks/TotalCompletedTasks.jsx
@@ -1,30 +1,15 @@
-import { toast } from "sonner";
-import { getMetrics } from "../../../services/metricsService.js";
 import { ContentGraphicTree } from "./TotalCompletedTasks.styles.js";
-import { useEffect, useState } from "react";
+import { useMetrics } from "../../../contexts/MetricsContext.jsx";
 
 export function TotalCompletedTasks() {
-	const [totalTasks, setTotalTasks] = useState();
-
-	useEffect(() => {
-		const getTotalCompletedTasks = async () => {
-			try {
-				const response = await getMetrics();
-				setTotalTasks(response.concluida);
-			} catch (error) {
-				toast.error(error.message);
-			}
-		};
-
-		getTotalCompletedTasks();
-	}, []);
+	const { totalTasksCompleted } = useMetrics();
 
 	return (
 		<ContentGraphicTree>
 			<p>
 				Tarefas <br /> <strong>Concluídas</strong>
 			</p>
-			<h1>+{totalTasks}</h1>
+			<h1>+{totalTasksCompleted}</h1>
 		</ContentGraphicTree>
 	);
 }

--- a/src/components/Metrics/TotalPendingTasks/TotalPendingTasks.jsx
+++ b/src/components/Metrics/TotalPendingTasks/TotalPendingTasks.jsx
@@ -1,30 +1,17 @@
-import { useEffect, useState } from "react";
 import { ContentGraphicTwo } from "./TotalPendingTasks.styles.js";
-import { getMetrics } from "../../../services/metricsService.js";
-import { toast } from "sonner";
+import { useMetrics } from "../../../contexts/MetricsContext";
 
-export function TotalPendingTasks() {
-    const [totalTasks, setTotaltasks] = useState();
-
-    useEffect(() => {
-        const getTotalPendingTasks = async () => {
-            try {
-                const response = await getMetrics();
-                setTotaltasks(response.pendente)
-            } catch (error) {
-                toast.error(error.message)
-            }
-        }
-
-        getTotalPendingTasks();
-    }, [totalTasks])
+function TotalPendingTasks() {
+	const { totalTasksPending } = useMetrics();
 
 	return (
 		<ContentGraphicTwo>
 			<p>
 				Tarefas <br /> <strong>Pendentes</strong>
 			</p>
-			<h1>{totalTasks}</h1>
+			<h1>{totalTasksPending}</h1>
 		</ContentGraphicTwo>
 	);
 }
+
+export { TotalPendingTasks };

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -1,4 +1,4 @@
-import { ButtonSelect } from "./Select.style"
+import { ButtonSelect } from "./Select.style";
 
 function SelectButton({ filter, setFilter }){
     return(
@@ -16,4 +16,4 @@ function SelectButton({ filter, setFilter }){
       )
 }
 
-export default SelectButton;
+export { SelectButton };

--- a/src/contexts/MetricsContext.jsx
+++ b/src/contexts/MetricsContext.jsx
@@ -1,0 +1,51 @@
+import { useContext, createContext, useEffect, useState } from "react";
+import { getMetrics } from "../services/metricsService";
+
+export const MetricsContext = createContext({});
+
+function MetricsProvider({ children }) {
+	const [totalTasks, setTotalTasks] = useState({});
+	const [loading, setLoading] = useState(false);
+	
+	useEffect(() => {
+		const acessToken = localStorage.getItem("@Notes:token");
+		if (acessToken) {
+			const getTotalPendingTasks = async () => {
+				setLoading(true);
+				try {
+					const response = await getMetrics();
+					const {pendente, concluida} = response;
+					setTotalTasks(prevstate => ({
+						...prevstate,
+						pendente,
+						concluida
+					}));
+				} catch (error) {
+					return error.message;
+				} finally {
+					setLoading(false)
+				}
+			};
+			getTotalPendingTasks();
+		}
+	}, []);
+
+	const context = {
+		totalTasksPending: totalTasks.pendente,
+		totalTasksCompleted: totalTasks.concluida,
+		loading
+	}	
+
+	return (
+		<MetricsContext.Provider value={context}>
+			{children}
+		</MetricsContext.Provider>
+	);
+}
+
+function useMetrics() {
+	const contextMetrics = useContext(MetricsContext);
+	return contextMetrics;
+}
+
+export { useMetrics, MetricsProvider };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,13 +6,16 @@ import { Routes } from "./routes/index.jsx";
 import GlobalStyle from "./styles/global";
 import theme from "./styles/theme";
 import { AuthProvider } from "./contexts/AuthContext.jsx";
+import { MetricsProvider } from "./contexts/MetricsContext.jsx";
 
 createRoot(document.getElementById("root")).render(
 	<StrictMode>
 		<ThemeProvider theme={theme}>
 			<GlobalStyle />
 			<AuthProvider>
-				<Routes />
+				<MetricsProvider>
+					<Routes />
+				</MetricsProvider>
 			</AuthProvider>
 		</ThemeProvider>
 	</StrictMode>,

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,8 +3,8 @@ import { toast } from "sonner";
 import { useAuth } from "../../contexts/AuthContext.jsx";
 
 import AddTask from "../../components/AddTask/AddTask";
-import HeaderNav from "../../components/Header/Header";
-import Select from "../../components/Select/Select";
+import { HeaderNav } from "../../components/Header/Header";
+import { SelectButton } from "../../components/Select/Select";
 import { CardTask } from "../../components/CardTasks/CardTasks.jsx";
 import { ToastPopUp } from "../../components/Toast/Toast.jsx";
 import { SearchNotes } from "../../components/SearchNotes/SearchNotes.jsx";
@@ -134,7 +134,7 @@ export default function Home() {
 							<h1>Suas Tarefas</h1>
 							<ActionsButtons>
 								<AddTask />
-								<Select filter={filter} setFilter={setFilter}/>
+								<SelectButton filter={filter} setFilter={setFilter}/>
 							</ActionsButtons>
 						</ContainerTitle>
 					</HeaderTasks>

--- a/src/pages/NovaNota/NovaNota.jsx
+++ b/src/pages/NovaNota/NovaNota.jsx
@@ -2,11 +2,12 @@ import { toast } from "sonner";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "react-router-dom";
 
-import Header from "../../components/Header/Header";
+import { HeaderNav } from "../../components/Header/Header";
 import { Input } from "../../components/Input/Input";
 import { useForm } from "react-hook-form";
 import { createNoteschema } from "../../utils/notesSchema";
 import { postNote } from "../../services/notesService";
+import { TextArea } from "../../components/TextArea/TextArea";
 
 import {
 	ContainerBody,
@@ -17,7 +18,7 @@ import {
 	ButtonCancel,
 	ContainerActionButtons,
 } from "../NovaNota/NovaNota.styles";
-import { TextArea } from "../../components/TextArea/TextArea";
+
 
 export default function NovaNota() {
 
@@ -57,7 +58,7 @@ export default function NovaNota() {
 
 	return (
 		<ContainerBody>
-			<Header showSearchBar={false} />
+			<HeaderNav showSearchBar={false} />
 			<MainContent onSubmit={handleSubmit(onSubmit)}>
 				<HeaderTitle>
 					<h1>Nova Tarefa</h1>

--- a/src/pages/Perfil/Perfil.jsx
+++ b/src/pages/Perfil/Perfil.jsx
@@ -1,4 +1,4 @@
-import HeaderNav from "../../components/Header/Header";
+import { HeaderNav } from "../../components/Header/Header";
 import { Input } from "../../components/Input/Input.jsx";
 import { MdOutlineEmail, MdOutlineLock } from "react-icons/md";
 import { FiCamera, FiUser } from "react-icons/fi";

--- a/src/services/metricsService.js
+++ b/src/services/metricsService.js
@@ -1,7 +1,13 @@
 import { api } from "./api";
 
 async function getMetrics() {
-    return await api.get("/notes/totals")
+    const acessToken = localStorage.getItem("@Notes:token");
+
+    return await api.get("/notes/totals", {
+        headers: {
+            authorization: `Bearer ${JSON.parse(acessToken)}`,
+        },
+    })
         .then((response) => {
             return response.data;
         }).catch((error) => {


### PR DESCRIPTION
- Criado um novo contexto chamado `MetricsContext` para gerenciar dados de métricas, incluindo um novo hook para utilização chamada `useMetrics`;
- Refatorado para usar `useMetrics` para buscar dados de métricas em vez de fazer chamadas de API diretamente;
- `HeaderNav` e `SelectButton` foram alterados de uma exportação padrão para uma exportação nomeada;
- Agora provisoriamente o botão profille desaparece em dispositivos menores;
- Adicionado cabeçalhos de autorização à função `getMetrics` para incluir o token de acesso nas solicitações para API.